### PR TITLE
Introduce TemplateRenderer for prompt templating

### DIFF
--- a/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/QuestionAnswerAdvisor.java
+++ b/advisors/spring-ai-advisors-vector-store/src/main/java/org/springframework/ai/chat/client/advisor/vectorstore/QuestionAnswerAdvisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.lang.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -49,6 +50,7 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Timo Salm
  * @author Ilayaperumal Gopinathan
+ * @author Thomas Vitale
  * @since 1.0.0
  */
 public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdvisor {
@@ -57,7 +59,7 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 
 	public static final String FILTER_EXPRESSION = "qa_filter_expression";
 
-	private static final String DEFAULT_USER_TEXT_ADVISE = """
+	private static final PromptTemplate DEFAULT_PROMPT_TEMPLATE = new PromptTemplate("""
 
 			Context information is below, surrounded by ---------------------
 
@@ -68,13 +70,13 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 			Given the context and provided history information and not prior knowledge,
 			reply to the user comment. If the answer is not in the context, inform
 			the user that you can't answer the question.
-			""";
+			""");
 
 	private static final int DEFAULT_ORDER = 0;
 
 	private final VectorStore vectorStore;
 
-	private final String userTextAdvise;
+	private final PromptTemplate promptTemplate;
 
 	private final SearchRequest searchRequest;
 
@@ -88,7 +90,7 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 	 * @param vectorStore The vector store to use
 	 */
 	public QuestionAnswerAdvisor(VectorStore vectorStore) {
-		this(vectorStore, SearchRequest.builder().build(), DEFAULT_USER_TEXT_ADVISE);
+		this(vectorStore, SearchRequest.builder().build(), DEFAULT_PROMPT_TEMPLATE, true, DEFAULT_ORDER);
 	}
 
 	/**
@@ -97,9 +99,11 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 	 * @param vectorStore The vector store to use
 	 * @param searchRequest The search request defined using the portable filter
 	 * expression syntax
+	 * @deprecated in favor of the builder: {@link #builder(VectorStore)}
 	 */
+	@Deprecated
 	public QuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest) {
-		this(vectorStore, searchRequest, DEFAULT_USER_TEXT_ADVISE);
+		this(vectorStore, searchRequest, DEFAULT_PROMPT_TEMPLATE, true, DEFAULT_ORDER);
 	}
 
 	/**
@@ -110,9 +114,12 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 	 * expression syntax
 	 * @param userTextAdvise The user text to append to the existing user prompt. The text
 	 * should contain a placeholder named "question_answer_context".
+	 * @deprecated in favor of the builder: {@link #builder(VectorStore)}
 	 */
+	@Deprecated
 	public QuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest, String userTextAdvise) {
-		this(vectorStore, searchRequest, userTextAdvise, true);
+		this(vectorStore, searchRequest, PromptTemplate.builder().template(userTextAdvise).build(), true,
+				DEFAULT_ORDER);
 	}
 
 	/**
@@ -127,10 +134,13 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 	 * blocking threads. If false the advisor will not protect the execution from blocking
 	 * threads. This is useful when the advisor is used in a non-blocking environment. It
 	 * is true by default.
+	 * @deprecated in favor of the builder: {@link #builder(VectorStore)}
 	 */
+	@Deprecated
 	public QuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest, String userTextAdvise,
 			boolean protectFromBlocking) {
-		this(vectorStore, searchRequest, userTextAdvise, protectFromBlocking, DEFAULT_ORDER);
+		this(vectorStore, searchRequest, PromptTemplate.builder().template(userTextAdvise).build(), protectFromBlocking,
+				DEFAULT_ORDER);
 	}
 
 	/**
@@ -146,17 +156,23 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 	 * threads. This is useful when the advisor is used in a non-blocking environment. It
 	 * is true by default.
 	 * @param order The order of the advisor.
+	 * @deprecated in favor of the builder: {@link #builder(VectorStore)}
 	 */
+	@Deprecated
 	public QuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest, String userTextAdvise,
 			boolean protectFromBlocking, int order) {
+		this(vectorStore, searchRequest, PromptTemplate.builder().template(userTextAdvise).build(), protectFromBlocking,
+				order);
+	}
 
-		Assert.notNull(vectorStore, "The vectorStore must not be null!");
-		Assert.notNull(searchRequest, "The searchRequest must not be null!");
-		Assert.hasText(userTextAdvise, "The userTextAdvise must not be empty!");
+	QuestionAnswerAdvisor(VectorStore vectorStore, SearchRequest searchRequest, @Nullable PromptTemplate promptTemplate,
+			boolean protectFromBlocking, int order) {
+		Assert.notNull(vectorStore, "vectorStore cannot be null");
+		Assert.notNull(searchRequest, "searchRequest cannot be null");
 
 		this.vectorStore = vectorStore;
 		this.searchRequest = searchRequest;
-		this.userTextAdvise = userTextAdvise;
+		this.promptTemplate = promptTemplate != null ? promptTemplate : DEFAULT_PROMPT_TEMPLATE;
 		this.protectFromBlocking = protectFromBlocking;
 		this.order = order;
 	}
@@ -212,10 +228,7 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 
 		var context = new HashMap<>(request.adviseContext());
 
-		// 1. Advise the system text.
-		String advisedUserText = request.userText() + System.lineSeparator() + this.userTextAdvise;
-
-		// 2. Search for similar documents in the vector store.
+		// 1. Search for similar documents in the vector store.
 		String query = new PromptTemplate(request.userText(), request.userParams()).render();
 		var searchRequestToUse = SearchRequest.from(this.searchRequest)
 			.query(query)
@@ -224,20 +237,21 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 
 		List<Document> documents = this.vectorStore.similaritySearch(searchRequestToUse);
 
-		// 3. Create the context from the documents.
+		// 2. Create the context from the documents.
 		context.put(RETRIEVED_DOCUMENTS, documents);
 
 		String documentContext = documents.stream()
 			.map(Document::getText)
 			.collect(Collectors.joining(System.lineSeparator()));
 
-		// 4. Advise the user parameters.
-		Map<String, Object> advisedUserParams = new HashMap<>(request.userParams());
-		advisedUserParams.put("question_answer_context", documentContext);
+		// 3. Augment the user prompt with the document context.
+		String augmentedUserText = this.promptTemplate.mutate()
+			.template(request.userText() + System.lineSeparator() + this.promptTemplate.getTemplate())
+			.build()
+			.render(Map.of("question_answer_context", documentContext));
 
 		AdvisedRequest advisedRequest = AdvisedRequest.from(request)
-			.userText(advisedUserText)
-			.userParams(advisedUserParams)
+			.userText(augmentedUserText)
 			.adviseContext(context)
 			.build();
 
@@ -266,7 +280,7 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 
 		private SearchRequest searchRequest = SearchRequest.builder().build();
 
-		private String userTextAdvise = DEFAULT_USER_TEXT_ADVISE;
+		private PromptTemplate promptTemplate;
 
 		private boolean protectFromBlocking = true;
 
@@ -283,9 +297,15 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 			return this;
 		}
 
+		public Builder promptTemplate(PromptTemplate promptTemplate) {
+			Assert.notNull(promptTemplate, "promptTemplate cannot be null");
+			this.promptTemplate = promptTemplate;
+			return this;
+		}
+
 		public Builder userTextAdvise(String userTextAdvise) {
 			Assert.hasText(userTextAdvise, "The userTextAdvise must not be empty!");
-			this.userTextAdvise = userTextAdvise;
+			this.promptTemplate = PromptTemplate.builder().template(userTextAdvise).build();
 			return this;
 		}
 
@@ -300,7 +320,7 @@ public class QuestionAnswerAdvisor implements CallAroundAdvisor, StreamAroundAdv
 		}
 
 		public QuestionAnswerAdvisor build() {
-			return new QuestionAnswerAdvisor(this.vectorStore, this.searchRequest, this.userTextAdvise,
+			return new QuestionAnswerAdvisor(this.vectorStore, this.searchRequest, this.promptTemplate,
 					this.protectFromBlocking, this.order);
 		}
 

--- a/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
+++ b/models/spring-ai-openai/src/test/java/org/springframework/ai/openai/chat/client/OpenAiChatClientIT.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.prompt.template.st.StTemplateRenderer;
 import reactor.core.publisher.Flux;
 
 import org.springframework.ai.chat.client.ChatClient;
@@ -219,8 +220,9 @@ class OpenAiChatClientIT extends AbstractIT {
 				.advisors(new SimpleLoggerAdvisor())
 				.user(u -> u
 						.text("Generate the filmography of 5 movies for Tom Hanks. " + System.lineSeparator()
-								+ "{format}")
+								+ "<format>")
 						.param("format", outputConverter.getFormat()))
+				.promptTemplateRenderer(StTemplateRenderer.builder().startDelimiterToken('<').endDelimiterToken('>').build())
 				.stream()
 				.chatResponse();
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/ChatClient.java
@@ -32,6 +32,7 @@ import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.template.TemplateRenderer;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.converter.StructuredOutputConverter;
 import org.springframework.ai.model.function.FunctionCallback;
@@ -254,6 +255,8 @@ public interface ChatClient {
 
 		ChatClientRequestSpec user(Consumer<PromptUserSpec> consumer);
 
+		ChatClientRequestSpec promptTemplateRenderer(TemplateRenderer templateRenderer);
+
 		CallResponseSpec call();
 
 		StreamResponseSpec stream();
@@ -312,6 +315,8 @@ public interface ChatClient {
 		Builder defaultFunctions(FunctionCallback... functionCallbacks);
 
 		Builder defaultToolContext(Map<String, Object> toolContext);
+
+		Builder defaultPromptTemplateRenderer(TemplateRenderer templateRenderer);
 
 		Builder clone();
 

--- a/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
+++ b/spring-ai-client-chat/src/main/java/org/springframework/ai/chat/client/DefaultChatClientBuilder.java
@@ -34,6 +34,7 @@ import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.template.TemplateRenderer;
 import org.springframework.ai.model.function.FunctionCallback;
 import org.springframework.ai.tool.ToolCallback;
 import org.springframework.ai.tool.ToolCallbackProvider;
@@ -67,7 +68,7 @@ public class DefaultChatClientBuilder implements Builder {
 		Assert.notNull(observationRegistry, "the " + ObservationRegistry.class.getName() + " must be non-null");
 		this.defaultRequest = new DefaultChatClientRequestSpec(chatModel, null, Map.of(), null, Map.of(), List.of(),
 				List.of(), List.of(), List.of(), null, List.of(), Map.of(), observationRegistry,
-				customObservationConvention, Map.of());
+				customObservationConvention, Map.of(), null);
 	}
 
 	public ChatClient build() {
@@ -209,6 +210,12 @@ public class DefaultChatClientBuilder implements Builder {
 
 	public Builder defaultToolContext(Map<String, Object> toolContext) {
 		this.defaultRequest.toolContext(toolContext);
+		return this;
+	}
+
+	public Builder defaultPromptTemplateRenderer(TemplateRenderer templateRenderer) {
+		Assert.notNull(templateRenderer, "templateRenderer cannot be null");
+		this.defaultRequest.promptTemplateRenderer(templateRenderer);
 		return this;
 	}
 

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientBuilderTests.java
@@ -95,4 +95,12 @@ class DefaultChatClientBuilderTests {
 			.hasMessage("charset cannot be null");
 	}
 
+	@Test
+	void whenTemplateRendererIsNullThenThrows() {
+		DefaultChatClientBuilder builder = new DefaultChatClientBuilder(mock(ChatModel.class));
+		assertThatThrownBy(() -> builder.defaultPromptTemplateRenderer(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("templateRenderer cannot be null");
+	}
+
 }

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/chat/client/DefaultChatClientTests.java
@@ -1300,7 +1300,7 @@ class DefaultChatClientTests {
 		ChatModel chatModel = mock(ChatModel.class);
 		DefaultChatClient.DefaultChatClientRequestSpec spec = new DefaultChatClient.DefaultChatClientRequestSpec(
 				chatModel, null, Map.of(), null, Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(),
-				Map.of(), ObservationRegistry.NOOP, null, Map.of());
+				Map.of(), ObservationRegistry.NOOP, null, Map.of(), null);
 		assertThat(spec).isNotNull();
 	}
 
@@ -1308,7 +1308,7 @@ class DefaultChatClientTests {
 	void whenChatModelIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(null, null, Map.of(), null,
 				Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(),
-				ObservationRegistry.NOOP, null, Map.of()))
+				ObservationRegistry.NOOP, null, Map.of(), null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("chatModel cannot be null");
 	}
@@ -1317,7 +1317,7 @@ class DefaultChatClientTests {
 	void whenObservationRegistryIsNullThenThrow() {
 		assertThatThrownBy(() -> new DefaultChatClient.DefaultChatClientRequestSpec(mock(ChatModel.class), null,
 				Map.of(), null, Map.of(), List.of(), List.of(), List.of(), List.of(), null, List.of(), Map.of(), null,
-				null, Map.of()))
+				null, Map.of(), null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("observationRegistry cannot be null");
 	}

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/prompt/PromptTemplateTest.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/prompt/PromptTemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ public class PromptTemplateTest {
 
 		PromptTemplate unfilledPromptTemplate = new PromptTemplate(templateString);
 		assertThatExceptionOfType(IllegalStateException.class).isThrownBy(unfilledPromptTemplate::render)
-			.withMessage("Not all template variables were replaced. Missing variable names are [items]");
+			.withMessage("Not all variables were replaced in the template. Missing variable names are: [items].");
 	}
 
 	@Test

--- a/spring-ai-client-chat/src/test/java/org/springframework/ai/prompt/PromptTests.java
+++ b/spring-ai-client-chat/src/test/java/org/springframework/ai/prompt/PromptTests.java
@@ -18,7 +18,6 @@ package org.springframework.ai.prompt;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -45,7 +44,7 @@ class PromptTests {
 		// Try to render with missing value for template variable, expect exception
 		Assertions.assertThatThrownBy(() -> pt.render(model))
 			.isInstanceOf(IllegalStateException.class)
-			.hasMessage("Not all template variables were replaced. Missing variable names are [lastName]");
+			.hasMessage("Not all variables were replaced in the template. Missing variable names are: [lastName].");
 
 		pt.add("lastName", "Park"); // TODO investigate partial
 		String promptString = pt.render(model);
@@ -91,44 +90,6 @@ class PromptTests {
 		// humanPrompt);
 		// Prompt chatPrompt chatPromptTemplate.create(generative);
 
-	}
-
-	@Test
-	void testSingleInputVariable() {
-		String template = "This is a {foo} test";
-		PromptTemplate promptTemplate = new PromptTemplate(template);
-		Set<String> inputVariables = promptTemplate.getInputVariables();
-		assertThat(inputVariables).isNotEmpty();
-		assertThat(inputVariables).hasSize(1);
-		assertThat(inputVariables).contains("foo");
-	}
-
-	@Test
-	void testMultipleInputVariables() {
-		String template = "This {bar} is a {foo} test";
-		PromptTemplate promptTemplate = new PromptTemplate(template);
-		Set<String> inputVariables = promptTemplate.getInputVariables();
-		assertThat(inputVariables).isNotEmpty();
-		assertThat(inputVariables).hasSize(2);
-		assertThat(inputVariables).contains("foo", "bar");
-	}
-
-	@Test
-	void testMultipleInputVariablesWithRepeats() {
-		String template = "This {bar} is a {foo} test {foo}.";
-		PromptTemplate promptTemplate = new PromptTemplate(template);
-		Set<String> inputVariables = promptTemplate.getInputVariables();
-		assertThat(inputVariables).isNotEmpty();
-		assertThat(inputVariables).hasSize(2);
-		assertThat(inputVariables).contains("foo", "bar");
-	}
-
-	@Test
-	void testBadFormatOfTemplateString() {
-		String template = "This is a {foo test";
-		Assertions.assertThatThrownBy(() -> new PromptTemplate(template))
-			.isInstanceOf(IllegalArgumentException.class)
-			.hasMessage("The template string is not valid.");
 	}
 
 	@Test

--- a/spring-ai-integration-tests/pom.xml
+++ b/spring-ai-integration-tests/pom.xml
@@ -63,6 +63,13 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-advisors-vector-store</artifactId>
+			<version>${project.parent.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-starter-model-openai</artifactId>
 			<version>${project.parent.version}</version>
 			<scope>test</scope>

--- a/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/QuestionAnswerAdvisorIT.java
+++ b/spring-ai-integration-tests/src/test/java/org/springframework/ai/integration/tests/client/advisor/QuestionAnswerAdvisorIT.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.integration.tests.client.advisor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.advisor.vectorstore.QuestionAnswerAdvisor;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.chat.prompt.template.st.StTemplateRenderer;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.document.DocumentReader;
+import org.springframework.ai.evaluation.EvaluationRequest;
+import org.springframework.ai.evaluation.EvaluationResponse;
+import org.springframework.ai.evaluation.RelevancyEvaluator;
+import org.springframework.ai.integration.tests.TestApplication;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.reader.markdown.MarkdownDocumentReader;
+import org.springframework.ai.reader.markdown.config.MarkdownDocumentReaderConfig;
+import org.springframework.ai.vectorstore.pgvector.PgVectorStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.Resource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for {@link QuestionAnswerAdvisor}.
+ *
+ * @author Thomas Vitale
+ */
+@SpringBootTest(classes = TestApplication.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".*")
+public class QuestionAnswerAdvisorIT {
+
+	private List<Document> knowledgeBaseDocuments;
+
+	@Autowired
+	OpenAiChatModel openAiChatModel;
+
+	@Autowired
+	PgVectorStore pgVectorStore;
+
+	@Value("${classpath:documents/knowledge-base.md}")
+	Resource knowledgeBaseResource;
+
+	@BeforeEach
+	void setUp() {
+		DocumentReader markdownReader = new MarkdownDocumentReader(this.knowledgeBaseResource,
+				MarkdownDocumentReaderConfig.defaultConfig());
+		this.knowledgeBaseDocuments = markdownReader.read();
+		this.pgVectorStore.add(this.knowledgeBaseDocuments);
+	}
+
+	@AfterEach
+	void tearDown() {
+		this.pgVectorStore.delete(this.knowledgeBaseDocuments.stream().map(Document::getId).toList());
+	}
+
+	@Test
+	void qaBasic() {
+		String question = "Where does the adventure of Anacletus and Birba take place?";
+
+		QuestionAnswerAdvisor qaAdvisor = QuestionAnswerAdvisor.builder(this.pgVectorStore).build();
+
+		ChatResponse chatResponse = ChatClient.builder(this.openAiChatModel)
+			.build()
+			.prompt(question)
+			.advisors(qaAdvisor)
+			.call()
+			.chatResponse();
+
+		assertThat(chatResponse).isNotNull();
+
+		String response = chatResponse.getResult().getOutput().getText();
+		System.out.println(response);
+		assertThat(response).containsIgnoringCase("Highlands");
+
+		evaluateRelevancy(question, chatResponse);
+	}
+
+	@Test
+	void qaCustomPrompt() {
+		PromptTemplate customPromptTemplate = PromptTemplate.builder()
+			.renderer(StTemplateRenderer.builder().startDelimiterToken('<').endDelimiterToken('>').build())
+			.template("""
+
+					Context information is below, surrounded by ---------------------
+
+					---------------------
+					<question_answer_context>
+					---------------------
+
+					Given the context and provided history information and not prior knowledge,
+					reply to the user comment. If the answer is not in the context, inform
+					the user that you can't answer the question.
+					""")
+			.build();
+
+		String question = "Where does the adventure of Anacletus and Birba take place?";
+
+		QuestionAnswerAdvisor qaAdvisor = QuestionAnswerAdvisor.builder(this.pgVectorStore)
+			.promptTemplate(customPromptTemplate)
+			.build();
+
+		ChatResponse chatResponse = ChatClient.builder(this.openAiChatModel)
+			.build()
+			.prompt(question)
+			.advisors(qaAdvisor)
+			.call()
+			.chatResponse();
+
+		assertThat(chatResponse).isNotNull();
+
+		String response = chatResponse.getResult().getOutput().getText();
+		System.out.println(response);
+		assertThat(response).containsIgnoringCase("Highlands");
+
+		evaluateRelevancy(question, chatResponse);
+	}
+
+	private void evaluateRelevancy(String question, ChatResponse chatResponse) {
+		EvaluationRequest evaluationRequest = new EvaluationRequest(question,
+				chatResponse.getMetadata().get(QuestionAnswerAdvisor.RETRIEVED_DOCUMENTS),
+				chatResponse.getResult().getOutput().getText());
+		RelevancyEvaluator evaluator = new RelevancyEvaluator(ChatClient.builder(this.openAiChatModel));
+		EvaluationResponse evaluationResponse = evaluator.evaluate(evaluationRequest);
+		assertThat(evaluationResponse.isPass()).isTrue();
+	}
+
+}

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/PromptTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 the original author or authors.
+ * Copyright 2023-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,128 +20,134 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.antlr.runtime.Token;
-import org.antlr.runtime.TokenStream;
-import org.stringtemplate.v4.ST;
-import org.stringtemplate.v4.compiler.STLexer;
-
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.template.TemplateRenderer;
+import org.springframework.ai.chat.prompt.template.st.StTemplateRenderer;
 import org.springframework.ai.content.Media;
 import org.springframework.core.io.Resource;
+import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
 
+/**
+ * A template for creating prompts. It allows you to define a template string with
+ * placeholders for variables, and then render the template with specific values for those
+ * variables.
+ *
+ * NOTE: This class will be marked as final in the next release. If you subclass this
+ * class, you should consider using the built-in implementation together with the new
+ * PromptTemplateRenderer interface, which is designed to give you more flexibility and
+ * control over the rendering process.
+ */
 public class PromptTemplate implements PromptTemplateActions, PromptTemplateMessageActions {
 
+	private static final TemplateRenderer DEFAULT_TEMPLATE_RENDERER = StTemplateRenderer.builder().build();
+
+	/**
+	 * @deprecated will become private in the next release. If you're subclassing this
+	 * class, re-consider using the built-in implementation together with the new
+	 * PromptTemplateRenderer interface, designed to give you more flexibility and control
+	 * over the rendering process.
+	 */
+	@Deprecated
 	protected String template;
 
+	/**
+	 * @deprecated in favor of {@link TemplateRenderer}
+	 */
+	@Deprecated
 	protected TemplateFormat templateFormat = TemplateFormat.ST;
 
-	private ST st;
+	private final Map<String, Object> variables = new HashMap<>();
 
-	private Map<String, Object> dynamicModel = new HashMap<>();
+	private final TemplateRenderer renderer;
 
 	public PromptTemplate(Resource resource) {
-		try (InputStream inputStream = resource.getInputStream()) {
-			this.template = StreamUtils.copyToString(inputStream, Charset.defaultCharset());
-		}
-		catch (IOException ex) {
-			throw new RuntimeException("Failed to read resource", ex);
-		}
-		try {
-			this.st = new ST(this.template, '{', '}');
-		}
-		catch (Exception ex) {
-			throw new IllegalArgumentException("The template string is not valid.", ex);
-		}
+		this(resource, new HashMap<>(), DEFAULT_TEMPLATE_RENDERER);
 	}
 
 	public PromptTemplate(String template) {
-		this.template = template;
-		// If the template string is not valid, an exception will be thrown
-		try {
-			this.st = new ST(this.template, '{', '}');
-		}
-		catch (Exception ex) {
-			throw new IllegalArgumentException("The template string is not valid.", ex);
-		}
+		this(template, new HashMap<>(), DEFAULT_TEMPLATE_RENDERER);
 	}
 
-	public PromptTemplate(String template, Map<String, Object> model) {
-		this.template = template;
-		// If the template string is not valid, an exception will be thrown
-		try {
-			this.st = new ST(this.template, '{', '}');
-			for (Entry<String, Object> entry : model.entrySet()) {
-				add(entry.getKey(), entry.getValue());
-			}
-		}
-		catch (Exception ex) {
-			throw new IllegalArgumentException("The template string is not valid.", ex);
-		}
+	public PromptTemplate(String template, Map<String, Object> variables) {
+		this(template, variables, DEFAULT_TEMPLATE_RENDERER);
 	}
 
-	public PromptTemplate(Resource resource, Map<String, Object> model) {
+	public PromptTemplate(Resource resource, Map<String, Object> variables) {
+		this(resource, variables, DEFAULT_TEMPLATE_RENDERER);
+	}
+
+	PromptTemplate(String template, Map<String, Object> variables, TemplateRenderer renderer) {
+		Assert.hasText(template, "template cannot be null or empty");
+		Assert.notNull(variables, "variables cannot be null");
+		Assert.noNullElements(variables.keySet(), "variables keys cannot be null");
+		Assert.notNull(renderer, "renderer cannot be null");
+
+		this.template = template;
+		this.variables.putAll(variables);
+		this.renderer = renderer;
+	}
+
+	PromptTemplate(Resource resource, Map<String, Object> variables, TemplateRenderer renderer) {
+		Assert.notNull(resource, "resource cannot be null");
+		Assert.notNull(variables, "variables cannot be null");
+		Assert.noNullElements(variables.keySet(), "variables keys cannot be null");
+		Assert.notNull(renderer, "renderer cannot be null");
+
 		try (InputStream inputStream = resource.getInputStream()) {
 			this.template = StreamUtils.copyToString(inputStream, Charset.defaultCharset());
+			Assert.hasText(template, "template cannot be null or empty");
 		}
 		catch (IOException ex) {
 			throw new RuntimeException("Failed to read resource", ex);
 		}
-		// If the template string is not valid, an exception will be thrown
-		try {
-			this.st = new ST(this.template, '{', '}');
-			for (Entry<String, Object> entry : model.entrySet()) {
-				this.add(entry.getKey(), entry.getValue());
-			}
-		}
-		catch (Exception ex) {
-			throw new IllegalArgumentException("The template string is not valid.", ex);
-		}
+		this.variables.putAll(variables);
+		this.renderer = renderer;
 	}
 
 	public void add(String name, Object value) {
-		this.st.add(name, value);
-		this.dynamicModel.put(name, value);
+		this.variables.put(name, value);
 	}
 
 	public String getTemplate() {
 		return this.template;
 	}
 
+	/**
+	 * @deprecated in favor of {@link TemplateRenderer}
+	 */
+	@Deprecated
 	public TemplateFormat getTemplateFormat() {
 		return this.templateFormat;
 	}
 
-	// Render Methods
+	// From PromptTemplateStringActions.
+
 	@Override
 	public String render() {
-		validate(this.dynamicModel);
-		return this.st.render();
+		return this.renderer.apply(template, this.variables);
 	}
 
 	@Override
-	public String render(Map<String, Object> model) {
-		validate(model);
-		for (Entry<String, Object> entry : model.entrySet()) {
-			if (this.st.getAttribute(entry.getKey()) != null) {
-				this.st.remove(entry.getKey());
-			}
+	public String render(Map<String, Object> additionalVariables) {
+		Map<String, Object> combinedVariables = new HashMap<>(this.variables);
+
+		for (Entry<String, Object> entry : additionalVariables.entrySet()) {
 			if (entry.getValue() instanceof Resource) {
-				this.st.add(entry.getKey(), renderResource((Resource) entry.getValue()));
+				combinedVariables.put(entry.getKey(), renderResource((Resource) entry.getValue()));
 			}
 			else {
-				this.st.add(entry.getKey(), entry.getValue());
+				combinedVariables.put(entry.getKey(), entry.getValue());
 			}
-
 		}
-		return this.st.render();
+
+		return this.renderer.apply(template, combinedVariables);
 	}
 
 	private String renderResource(Resource resource) {
@@ -152,6 +158,8 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 			throw new RuntimeException(e);
 		}
 	}
+
+	// From PromptTemplateMessageActions.
 
 	@Override
 	public Message createMessage() {
@@ -164,9 +172,11 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 	}
 
 	@Override
-	public Message createMessage(Map<String, Object> model) {
-		return new UserMessage(render(model));
+	public Message createMessage(Map<String, Object> additionalVariables) {
+		return new UserMessage(render(additionalVariables));
 	}
+
+	// From PromptTemplateActions.
 
 	@Override
 	public Prompt create() {
@@ -179,59 +189,89 @@ public class PromptTemplate implements PromptTemplateActions, PromptTemplateMess
 	}
 
 	@Override
-	public Prompt create(Map<String, Object> model) {
-		return new Prompt(render(model));
+	public Prompt create(Map<String, Object> additionalVariables) {
+		return new Prompt(render(additionalVariables));
 	}
 
 	@Override
-	public Prompt create(Map<String, Object> model, ChatOptions modelOptions) {
-		return new Prompt(render(model), modelOptions);
+	public Prompt create(Map<String, Object> additionalVariables, ChatOptions modelOptions) {
+		return new Prompt(render(additionalVariables), modelOptions);
 	}
 
+	// Compatibility
+
+	/**
+	 * @deprecated in favor of {@link TemplateRenderer}.
+	 */
+	@Deprecated
 	public Set<String> getInputVariables() {
-		TokenStream tokens = this.st.impl.tokens;
-		Set<String> inputVariables = new HashSet<>();
-		boolean isInsideList = false;
-
-		for (int i = 0; i < tokens.size(); i++) {
-			Token token = tokens.get(i);
-
-			if (token.getType() == STLexer.LDELIM && i + 1 < tokens.size()
-					&& tokens.get(i + 1).getType() == STLexer.ID) {
-				if (i + 2 < tokens.size() && tokens.get(i + 2).getType() == STLexer.COLON) {
-					inputVariables.add(tokens.get(i + 1).getText());
-					isInsideList = true;
-				}
-			}
-			else if (token.getType() == STLexer.RDELIM) {
-				isInsideList = false;
-			}
-			else if (!isInsideList && token.getType() == STLexer.ID) {
-				inputVariables.add(token.getText());
-			}
-		}
-
-		return inputVariables;
+		throw new UnsupportedOperationException(
+				"The template rendering logic is now provided by PromptTemplateRenderer");
 	}
 
-	private Set<String> getModelKeys(Map<String, Object> model) {
-		Set<String> dynamicVariableNames = new HashSet<>(this.dynamicModel.keySet());
-		Set<String> modelVariables = new HashSet<>(model.keySet());
-		modelVariables.addAll(dynamicVariableNames);
-		return modelVariables;
-	}
-
+	/**
+	 * @deprecated in favor of {@link TemplateRenderer}.
+	 */
+	@Deprecated
 	protected void validate(Map<String, Object> model) {
+		throw new UnsupportedOperationException("Validation is now provided by the PromptTemplateRenderer");
+	}
 
-		Set<String> templateTokens = getInputVariables();
-		Set<String> modelKeys = getModelKeys(model);
+	public Builder mutate() {
+		return new Builder().template(this.template).variables(this.variables).renderer(this.renderer);
+	}
 
-		// Check if model provides all keys required by the template
-		if (!modelKeys.containsAll(templateTokens)) {
-			templateTokens.removeAll(modelKeys);
-			throw new IllegalStateException(
-					"Not all template variables were replaced. Missing variable names are " + templateTokens);
+	// Builder
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private String template;
+
+		private Resource resource;
+
+		private Map<String, Object> variables = new HashMap<>();
+
+		private TemplateRenderer renderer = DEFAULT_TEMPLATE_RENDERER;
+
+		private Builder() {
 		}
+
+		public Builder template(String template) {
+			this.template = template;
+			return this;
+		}
+
+		public Builder resource(Resource resource) {
+			this.resource = resource;
+			return this;
+		}
+
+		public Builder variables(Map<String, Object> variables) {
+			this.variables = variables;
+			return this;
+		}
+
+		public Builder renderer(TemplateRenderer renderer) {
+			this.renderer = renderer;
+			return this;
+		}
+
+		public PromptTemplate build() {
+			if (this.template != null && this.resource != null) {
+				throw new IllegalArgumentException("Only one of template or resource can be set");
+			}
+			else if (this.resource != null) {
+				return new PromptTemplate(this.resource, this.variables, this.renderer);
+			}
+			else {
+				return new PromptTemplate(this.template, this.variables, this.renderer);
+			}
+		}
+
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/template/NoOpTemplateRenderer.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/template/NoOpTemplateRenderer.java
@@ -14,33 +14,26 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.chat.prompt;
+package org.springframework.ai.chat.prompt.template;
+
+import java.util.Map;
+
+import org.springframework.util.Assert;
 
 /**
- * @deprecated in favor of {@link TemplateRenderer}.
+ * No-op implementation of {@link TemplateRenderer} that returns the template unchanged.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
  */
-@Deprecated
-public enum TemplateFormat {
+public class NoOpTemplateRenderer implements TemplateRenderer {
 
-	ST("ST");
-
-	private final String value;
-
-	TemplateFormat(String value) {
-		this.value = value;
-	}
-
-	public static TemplateFormat fromValue(String value) {
-		for (TemplateFormat templateFormat : TemplateFormat.values()) {
-			if (templateFormat.getValue().equals(value)) {
-				return templateFormat;
-			}
-		}
-		throw new IllegalArgumentException("Invalid TemplateFormat value: " + value);
-	}
-
-	public String getValue() {
-		return this.value;
+	@Override
+	public String apply(String template, Map<String, Object> variables) {
+		Assert.hasText(template, "template cannot be null or empty");
+		Assert.notNull(variables, "variables cannot be null");
+		Assert.noNullElements(variables.keySet(), "variables keys cannot be null");
+		return template;
 	}
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/template/TemplateRenderer.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/template/TemplateRenderer.java
@@ -14,33 +14,20 @@
  * limitations under the License.
  */
 
-package org.springframework.ai.chat.prompt;
+package org.springframework.ai.chat.prompt.template;
+
+import java.util.Map;
+import java.util.function.BiFunction;
 
 /**
- * @deprecated in favor of {@link TemplateRenderer}.
+ * Renders a template using a given strategy.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
  */
-@Deprecated
-public enum TemplateFormat {
+public interface TemplateRenderer extends BiFunction<String, Map<String, Object>, String> {
 
-	ST("ST");
-
-	private final String value;
-
-	TemplateFormat(String value) {
-		this.value = value;
-	}
-
-	public static TemplateFormat fromValue(String value) {
-		for (TemplateFormat templateFormat : TemplateFormat.values()) {
-			if (templateFormat.getValue().equals(value)) {
-				return templateFormat;
-			}
-		}
-		throw new IllegalArgumentException("Invalid TemplateFormat value: " + value);
-	}
-
-	public String getValue() {
-		return this.value;
-	}
+	@Override
+	String apply(String template, Map<String, Object> variables);
 
 }

--- a/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/template/st/StTemplateRenderer.java
+++ b/spring-ai-model/src/main/java/org/springframework/ai/chat/prompt/template/st/StTemplateRenderer.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.prompt.template.st;
+
+import org.antlr.runtime.Token;
+import org.antlr.runtime.TokenStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.chat.prompt.template.TemplateRenderer;
+import org.springframework.util.Assert;
+import org.stringtemplate.v4.ST;
+import org.stringtemplate.v4.compiler.STLexer;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Renders a template using the StringTemplate (ST) library.
+ *
+ * @author Thomas Vitale
+ * @since 1.0.0
+ */
+public class StTemplateRenderer implements TemplateRenderer {
+
+	private static final Logger logger = LoggerFactory.getLogger(StTemplateRenderer.class);
+
+	private static final String VALIDATION_MESSAGE = "Not all variables were replaced in the template. Missing variable names are: %s.";
+
+	private static final char DEFAULT_START_DELIMITER_TOKEN = '{';
+
+	private static final char DEFAULT_END_DELIMITER_TOKEN = '}';
+
+	private static final ValidationMode DEFAULT_VALIDATION_MODE = ValidationMode.THROW;
+
+	private final char startDelimiterToken;
+
+	private final char endDelimiterToken;
+
+	private final ValidationMode validationMode;
+
+	StTemplateRenderer(char startDelimiterToken, char endDelimiterToken, ValidationMode validationMode) {
+		Assert.notNull(validationMode, "validationMode cannot be null");
+		this.startDelimiterToken = startDelimiterToken;
+		this.endDelimiterToken = endDelimiterToken;
+		this.validationMode = validationMode;
+	}
+
+	@Override
+	public String apply(String template, Map<String, Object> variables) {
+		Assert.hasText(template, "template cannot be null or empty");
+		Assert.notNull(variables, "variables cannot be null");
+		Assert.noNullElements(variables.keySet(), "variables keys cannot be null");
+
+		ST st = createST(template);
+		if (variables != null) {
+			for (Map.Entry<String, Object> entry : variables.entrySet()) {
+				st.add(entry.getKey(), entry.getValue());
+			}
+		}
+		if (validationMode != ValidationMode.NONE) {
+			validate(st, variables);
+		}
+		return st.render();
+	}
+
+	private ST createST(String template) {
+		try {
+			return new ST(template, startDelimiterToken, endDelimiterToken);
+		}
+		catch (Exception ex) {
+			throw new IllegalArgumentException("The template string is not valid.", ex);
+		}
+	}
+
+	private void validate(ST st, Map<String, Object> templateVariables) {
+		Set<String> templateTokens = getInputVariables(st);
+		Set<String> modelKeys = templateVariables != null ? templateVariables.keySet() : new HashSet<>();
+
+		// Check if model provides all keys required by the template
+		if (!modelKeys.containsAll(templateTokens)) {
+			templateTokens.removeAll(modelKeys);
+			if (validationMode == ValidationMode.WARN) {
+				logger.warn(VALIDATION_MESSAGE.formatted(templateTokens));
+			}
+			else if (validationMode == ValidationMode.THROW) {
+				throw new IllegalStateException(VALIDATION_MESSAGE.formatted(templateTokens));
+			}
+		}
+	}
+
+	private Set<String> getInputVariables(ST st) {
+		TokenStream tokens = st.impl.tokens;
+		Set<String> inputVariables = new HashSet<>();
+		boolean isInsideList = false;
+
+		for (int i = 0; i < tokens.size(); i++) {
+			Token token = tokens.get(i);
+
+			if (token.getType() == STLexer.LDELIM && i + 1 < tokens.size()
+					&& tokens.get(i + 1).getType() == STLexer.ID) {
+				if (i + 2 < tokens.size() && tokens.get(i + 2).getType() == STLexer.COLON) {
+					inputVariables.add(tokens.get(i + 1).getText());
+					isInsideList = true;
+				}
+			}
+			else if (token.getType() == STLexer.RDELIM) {
+				isInsideList = false;
+			}
+			else if (!isInsideList && token.getType() == STLexer.ID) {
+				inputVariables.add(token.getText());
+			}
+		}
+
+		return inputVariables;
+	}
+
+	public enum ValidationMode {
+
+		/**
+		 * If the validation fails, an exception is thrown. This is the default mode.
+		 */
+		THROW,
+
+		/**
+		 * If the validation fails, a warning is logged. The template is rendered with the
+		 * missing placeholders/variables. This mode is not recommended for production
+		 * use.
+		 */
+		WARN,
+
+		/**
+		 * No validation is performed.
+		 */
+		NONE;
+
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static class Builder {
+
+		private char startDelimiterToken = DEFAULT_START_DELIMITER_TOKEN;
+
+		private char endDelimiterToken = DEFAULT_END_DELIMITER_TOKEN;
+
+		private ValidationMode validationMode = DEFAULT_VALIDATION_MODE;
+
+		private Builder() {
+		}
+
+		public Builder startDelimiterToken(char startDelimiterToken) {
+			this.startDelimiterToken = startDelimiterToken;
+			return this;
+		}
+
+		public Builder endDelimiterToken(char endDelimiterToken) {
+			this.endDelimiterToken = endDelimiterToken;
+			return this;
+		}
+
+		public Builder validationMode(ValidationMode validationMode) {
+			this.validationMode = validationMode;
+			return this;
+		}
+
+		public StTemplateRenderer build() {
+			return new StTemplateRenderer(startDelimiterToken, endDelimiterToken, validationMode);
+		}
+
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/PromptTemplateTests.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.prompt;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.prompt.template.NoOpTemplateRenderer;
+import org.springframework.ai.chat.prompt.template.TemplateRenderer;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link PromptTemplate}.
+ *
+ * @author Thomas Vitale
+ */
+class PromptTemplateTests {
+
+	@Test
+	void createWithValidTemplate() {
+		String template = "Hello {name}!";
+		PromptTemplate promptTemplate = new PromptTemplate(template);
+		assertThat(promptTemplate.getTemplate()).isEqualTo(template);
+	}
+
+	@Test
+	void createWithEmptyTemplate() {
+		assertThatThrownBy(() -> new PromptTemplate("")).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("template cannot be null or empty");
+	}
+
+	@Test
+	void createWithNullTemplate() {
+		String template = null;
+		assertThatThrownBy(() -> new PromptTemplate(template)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("template cannot be null or empty");
+	}
+
+	@Test
+	void createWithValidResource() {
+		String content = "Hello {name}!";
+		Resource resource = new ByteArrayResource(content.getBytes());
+		PromptTemplate promptTemplate = new PromptTemplate(resource);
+		assertThat(promptTemplate.getTemplate()).isEqualTo(content);
+	}
+
+	@Test
+	void createWithNullResource() {
+		Resource resource = null;
+		assertThatThrownBy(() -> new PromptTemplate(resource)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("resource cannot be null");
+	}
+
+	@Test
+	void createWithNullVariables() {
+		String template = "Hello!";
+		Map<String, Object> variables = null;
+		assertThatThrownBy(() -> new PromptTemplate(template, variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("variables cannot be null");
+	}
+
+	@Test
+	void createWithNullVariableKeys() {
+		String template = "Hello!";
+		Map<String, Object> variables = new HashMap<>();
+		variables.put(null, "value");
+		assertThatThrownBy(() -> new PromptTemplate(template, variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("variables keys cannot be null");
+	}
+
+	@Test
+	void addVariable() {
+		PromptTemplate promptTemplate = new PromptTemplate("Hello {name}!");
+		promptTemplate.add("name", "Spring AI");
+		assertThat(promptTemplate.render()).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void renderWithoutVariables() {
+		PromptTemplate promptTemplate = new PromptTemplate("Hello!");
+		assertThat(promptTemplate.render()).isEqualTo("Hello!");
+	}
+
+	@Test
+	void renderWithVariables() {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+		PromptTemplate promptTemplate = new PromptTemplate("Hello {name}!", variables);
+		assertThat(promptTemplate.render()).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void renderWithAdditionalVariables() {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+		PromptTemplate promptTemplate = new PromptTemplate("{greeting} {name}!", variables);
+
+		Map<String, Object> additionalVariables = new HashMap<>();
+		additionalVariables.put("name", "Spring AI");
+		assertThat(promptTemplate.render(additionalVariables)).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void renderWithResourceVariable() {
+		String resourceContent = "Spring AI";
+		Resource resource = new ByteArrayResource(resourceContent.getBytes());
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("content", resource);
+
+		PromptTemplate promptTemplate = new PromptTemplate("Hello {content}!");
+		assertThat(promptTemplate.render(variables)).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void createMessageWithoutVariables() {
+		PromptTemplate promptTemplate = new PromptTemplate("Hello!");
+		Message message = promptTemplate.createMessage();
+		assertThat(message).isInstanceOf(UserMessage.class);
+		assertThat(message.getText()).isEqualTo("Hello!");
+	}
+
+	@Test
+	void createMessageWithVariables() {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+		PromptTemplate promptTemplate = new PromptTemplate("Hello {name}!");
+		Message message = promptTemplate.createMessage(variables);
+		assertThat(message).isInstanceOf(UserMessage.class);
+		assertThat(message.getText()).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void createPromptWithoutVariables() {
+		PromptTemplate promptTemplate = new PromptTemplate("Hello!");
+		Prompt prompt = promptTemplate.create();
+		assertThat(prompt.getContents()).isEqualTo("Hello!");
+	}
+
+	@Test
+	void createPromptWithVariables() {
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+		PromptTemplate promptTemplate = new PromptTemplate("Hello {name}!");
+		Prompt prompt = promptTemplate.create(variables);
+		assertThat(prompt.getContents()).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void createWithCustomRenderer() {
+		TemplateRenderer customRenderer = new NoOpTemplateRenderer();
+		PromptTemplate promptTemplate = PromptTemplate.builder()
+			.template("Hello {name}!")
+			.renderer(customRenderer)
+			.build();
+		assertThat(promptTemplate.render()).isEqualTo("Hello {name}!");
+	}
+
+	@Test
+	void builderShouldNotAllowBothTemplateAndResource() {
+		String template = "Hello!";
+		Resource resource = new ByteArrayResource(template.getBytes());
+
+		assertThatThrownBy(() -> PromptTemplate.builder().template(template).resource(resource).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("Only one of template or resource can be set");
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/render/NoOpPromptTemplateRendererTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/render/NoOpPromptTemplateRendererTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.prompt.render;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.prompt.template.NoOpTemplateRenderer;
+
+/**
+ * Unit tests for {@link NoOpTemplateRenderer}.
+ *
+ * @author Thomas Vitale
+ */
+class NoOpPromptTemplateRendererTests {
+
+	@Test
+	void shouldReturnUnchangedTemplate() {
+		NoOpTemplateRenderer renderer = new NoOpTemplateRenderer();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+
+		String result = renderer.apply("Hello {name}!", variables);
+
+		assertThat(result).isEqualTo("Hello {name}!");
+	}
+
+	@Test
+	void shouldReturnUnchangedTemplateWithMultipleVariables() {
+		NoOpTemplateRenderer renderer = new NoOpTemplateRenderer();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+		variables.put("name", "Spring AI");
+		variables.put("punctuation", "!");
+
+		String result = renderer.apply("{greeting} {name}{punctuation}", variables);
+
+		assertThat(result).isEqualTo("{greeting} {name}{punctuation}");
+	}
+
+	@Test
+	void shouldNotAcceptEmptyTemplate() {
+		NoOpTemplateRenderer renderer = new NoOpTemplateRenderer();
+		Map<String, Object> variables = new HashMap<>();
+
+		assertThatThrownBy(() -> renderer.apply("", variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("template cannot be null or empty");
+	}
+
+	@Test
+	void shouldNotAcceptNullTemplate() {
+		NoOpTemplateRenderer renderer = new NoOpTemplateRenderer();
+		Map<String, Object> variables = new HashMap<>();
+
+		assertThatThrownBy(() -> renderer.apply(null, variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("template cannot be null or empty");
+	}
+
+	@Test
+	void shouldNotAcceptNullVariables() {
+		NoOpTemplateRenderer renderer = new NoOpTemplateRenderer();
+		String template = "Hello!";
+
+		assertThatThrownBy(() -> renderer.apply(template, null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("variables cannot be null");
+	}
+
+	@Test
+	void shouldNotAcceptVariablesWithNullKeySet() {
+		NoOpTemplateRenderer renderer = new NoOpTemplateRenderer();
+		String template = "Hello!";
+		Map<String, Object> variables = new HashMap<String, Object>();
+		variables.put(null, "Spring AI");
+
+		assertThatThrownBy(() -> renderer.apply(template, variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("variables keys cannot be null");
+	}
+
+	@Test
+	void shouldReturnUnchangedComplexTemplate() {
+		NoOpTemplateRenderer renderer = new NoOpTemplateRenderer();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("header", "Welcome");
+		variables.put("user", "Spring AI");
+		variables.put("items", "one, two, three");
+		variables.put("footer", "Goodbye");
+
+		String template = """
+				{header}
+				User: {user}
+				Items: {items}
+				{footer}
+				""";
+
+		String result = renderer.apply(template, variables);
+
+		assertThat(result).isEqualToNormalizingNewlines(template);
+	}
+
+}

--- a/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/render/st/STPromptTemplateRendererTests.java
+++ b/spring-ai-model/src/test/java/org/springframework/ai/chat/prompt/render/st/STPromptTemplateRendererTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2023-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.chat.prompt.render.st;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.prompt.template.st.StTemplateRenderer;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit tests for {@link StTemplateRenderer}.
+ *
+ * @author Thomas Vitale
+ */
+class STPromptTemplateRendererTests {
+
+	@Test
+	void shouldNotAcceptNullValidationMode() {
+		assertThatThrownBy(() -> StTemplateRenderer.builder().validationMode(null).build())
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("validationMode cannot be null");
+	}
+
+	@Test
+	void shouldUseDefaultValuesWhenUsingBuilder() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+
+		assertThat(ReflectionTestUtils.getField(renderer, "startDelimiterToken")).isEqualTo('{');
+		assertThat(ReflectionTestUtils.getField(renderer, "endDelimiterToken")).isEqualTo('}');
+		assertThat(ReflectionTestUtils.getField(renderer, "validationMode"))
+			.isEqualTo(StTemplateRenderer.ValidationMode.THROW);
+	}
+
+	@Test
+	void shouldRenderTemplateWithSingleVariable() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+
+		String result = renderer.apply("Hello {name}!", variables);
+
+		assertThat(result).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void shouldRenderTemplateWithMultipleVariables() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+		variables.put("name", "Spring AI");
+		variables.put("punctuation", "!");
+
+		String result = renderer.apply("{greeting} {name}{punctuation}", variables);
+
+		assertThat(result).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void shouldNotRenderEmptyTemplate() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+
+		assertThatThrownBy(() -> renderer.apply("", variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("template cannot be null or empty");
+	}
+
+	@Test
+	void shouldNotAcceptNullVariables() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		assertThatThrownBy(() -> renderer.apply("Hello!", null)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("variables cannot be null");
+	}
+
+	@Test
+	void shouldNotAcceptVariablesWithNullKeySet() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		String template = "Hello!";
+		Map<String, Object> variables = new HashMap<String, Object>();
+		variables.put(null, "Spring AI");
+
+		assertThatThrownBy(() -> renderer.apply(template, variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("variables keys cannot be null");
+	}
+
+	@Test
+	void shouldThrowExceptionForInvalidTemplateSyntax() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+
+		assertThatThrownBy(() -> renderer.apply("Hello {name!", variables)).isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("The template string is not valid.");
+	}
+
+	@Test
+	void shouldThrowExceptionForMissingVariablesInThrowMode() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+
+		assertThatThrownBy(() -> renderer.apply("{greeting} {name}!", variables))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining(
+					"Not all variables were replaced in the template. Missing variable names are: [name]");
+	}
+
+	@Test
+	void shouldContinueRenderingWithMissingVariablesInWarnMode() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder()
+			.validationMode(StTemplateRenderer.ValidationMode.WARN)
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+
+		String result = renderer.apply("{greeting} {name}!", variables);
+
+		assertThat(result).isEqualTo("Hello !");
+	}
+
+	@Test
+	void shouldRenderWithoutValidationInNoneMode() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder()
+			.validationMode(StTemplateRenderer.ValidationMode.NONE)
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("greeting", "Hello");
+
+		String result = renderer.apply("{greeting} {name}!", variables);
+
+		assertThat(result).isEqualTo("Hello !");
+	}
+
+	@Test
+	void shouldRenderWithCustomDelimiters() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder()
+			.startDelimiterToken('<')
+			.endDelimiterToken('>')
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+
+		String result = renderer.apply("Hello <name>!", variables);
+
+		assertThat(result).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void shouldHandleSpecialCharactersAsDelimiters() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder()
+			.startDelimiterToken('$')
+			.endDelimiterToken('$')
+			.build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("name", "Spring AI");
+
+		String result = renderer.apply("Hello $name$!", variables);
+
+		assertThat(result).isEqualTo("Hello Spring AI!");
+	}
+
+	@Test
+	void shouldHandleComplexTemplateStructures() {
+		StTemplateRenderer renderer = StTemplateRenderer.builder().build();
+		Map<String, Object> variables = new HashMap<>();
+		variables.put("header", "Welcome");
+		variables.put("user", "Spring AI");
+		variables.put("items", "one, two, three");
+		variables.put("footer", "Goodbye");
+
+		String result = renderer.apply("""
+				{header}
+				User: {user}
+				Items: {items}
+				{footer}
+				""", variables);
+
+		assertThat(result).isEqualToNormalizingNewlines("""
+				Welcome
+				User: Spring AI
+				Items: one, two, three
+				Goodbye
+				""");
+	}
+
+}


### PR DESCRIPTION
- Introduce new TemplateRenderer API providing the logic for rendering an input template.
- Update the PromptTemplate API to accept a TemplateRenderer object at construction time.
- Move ST logic to StTemplateRenderer implementation, used by default in PromptTemplate. Additionally, make start and end delimiter character configurable.
- Extend ChatClient API to support passing a custom TemplateRenderer.

Relates to gh-2655

![Untitled-2025-04-16-0204](https://github.com/user-attachments/assets/eb52fe28-2d1a-4f16-9462-ca5efcdf9275)

